### PR TITLE
Fix bug where the same plot could appear multiple times

### DIFF
--- a/pyganja/script_api.py
+++ b/pyganja/script_api.py
@@ -65,7 +65,7 @@ def generate_notebook_js(script_json, sig=None, grid=True, scale=1.0, gl=True):
         scalestr = str(scale)
         js = read_ganja()
         js += """
-        function add_graph_to_notebook(Algebra){
+        requirejs(['Algebra'], function(Algebra) {
             var output = Algebra({p:"""+str(p)+""",q:"""+str(q)+""",r:"""+str(r)+""",baseType:Float64Array},()=>{
                 // When we get a file, we load and display.
                 var canvas;
@@ -96,9 +96,7 @@ def generate_notebook_js(script_json, sig=None, grid=True, scale=1.0, gl=True):
             }
             a.onclick = screenshot
             var butnelem = element.append(a);
-        }
-        // requirejs works in sphinx, require works in jupyter
-        (requirejs || require)(['Algebra'],function(Algebra){add_graph_to_notebook(Algebra)});
+        });
         """
     else:
         raise ValueError('Algebra not yet supported')


### PR DESCRIPTION
Notebook html generated with pyganja output would contain javscript akin to:

```javascript
function add_graph_to_notebook() { foo(); }
call_soon(() => add_graph_to_notebook());
function add_graph_to_notebook() { bar(); }
call_soon(() => add_graph_to_notebook());
```

If line 3 runs before `soon` expires on line 2, then `bar()` gets called twice, and `foo()` doesn't get called at all.

This fixes things by not naming the function at all.

It seems the comment about `requirejs` vs `require` was wrong - `requirejs` works in both places.

Fixes pygae/clifford#170