### PR TITLE
Allow tuple colors to be put directly into GanjaScene

### DIFF
--- a/pyganja/GanjaScene.py
+++ b/pyganja/GanjaScene.py
@@ -1,6 +1,6 @@
 
 import json
-import enum
+from . import color as _color
 
 
 def _as_list(mv_array):
@@ -41,12 +41,9 @@ class GanjaScene:
         else:
             raise ValueError('The objects being added are not both GanjaScenes...')
 
-    def add_object(self, mv_array, color=int('AA000000', 16), label=None, static=False):
+    def add_object(self, mv_array, color=0xAA000000, label=None, static=False):
         self.mv_length = len(mv_array)
-        if isinstance(color, enum.Enum):
-            self.internal_list.append(color.value)
-        else:
-            self.internal_list.append(color)
+        self.internal_list.append(_color.as_hex(color))
         if static:
             self.internal_list.append({'data': [_as_list(mv_array)]})
         else:
@@ -58,11 +55,8 @@ class GanjaScene:
             except:
                 raise ValueError('Labels must be strings')
 
-    def add_facet(self, mv_list, color=int('AA000000', 16), label=None, static=False):
-        if isinstance(color, enum.Enum):
-            self.internal_list.append(color.value)
-        else:
-            self.internal_list.append(color)
+    def add_facet(self, mv_list, color=0xAA000000, label=None, static=False):
+        self.internal_list.append(_color.as_hex(color))
         self.mv_length = len(mv_list[0])
         facet_list = []
         for mv_array in mv_list:
@@ -78,7 +72,7 @@ class GanjaScene:
             except:
                 raise ValueError('Labels must be strings')
 
-    def add_facets(self, mv_list, color=int('AA000000', 16), label=None, static=False):
+    def add_facets(self, mv_list, color=0xAA000000, label=None, static=False):
         for mv_array in mv_list:
             self.add_facet(mv_array,color=color, label=label, static=static)
         if label is not None:
@@ -88,11 +82,8 @@ class GanjaScene:
             except:
                 raise ValueError('Labels must be strings')
 
-    def add_objects(self, mv_list, color=int('AA000000', 16), label=None, static=False):
-        if isinstance(color, enum.Enum):
-            self.internal_list.append(color.value)
-        else:
-            self.internal_list.append(color)
+    def add_objects(self, mv_list, color=0xAA000000, label=None, static=False):
+        self.internal_list.append(_color.as_hex(color))
         static_list = []
         self.mv_length = len(mv_list[0])
         for mv_array in mv_list:

--- a/pyganja/__init__.py
+++ b/pyganja/__init__.py
@@ -1,4 +1,4 @@
 
 from .script_api import *
-from .color import *
+from .color import Color, rgb2hex
 from ._version import __version__

--- a/pyganja/color.py
+++ b/pyganja/color.py
@@ -1,19 +1,42 @@
-
-from enum import Enum
+import numbers
+from enum import IntEnum
+import operator
 
 def rgb2hex(x):
-    if len(x) == 3:
-        return int('%02x%02x%02x' %(int(x[0]),int(x[1]),int(x[2])),16)
-    elif len(x) == 4:
-        return int('%02x%02x%02x%02x' %(int(x[0]),int(x[1]),int(x[2]),int(x[3])),16)
+    if len(x) in (3, 4):
+        val = 0
+        for xi in x:
+            val = (val << 8) | _entry_as_uint8(xi)
+        return val
     else:
         raise ValueError('X must be of length 3 or 4, ie. an rgb or argb array')
 
-class Color(Enum):
-    BLUE = int('000000FF', 16)
-    RED = int('00FF0000', 16)
-    GREEN = int('0000FF00', 16)
-    YELLOW = int('00FFFF00', 16)
-    MAGENTA = int('00FF00FF', 16)
-    CYAN = int('0000FFFF', 16)
-    BLACK = int('00000000', 16)
+
+def _entry_as_uint8(v):
+    if isinstance(v, numbers.Integral):
+        if v > 255:
+            return 255
+        elif v < 0:
+            return 0
+        else:
+            return operator.index(v)
+    else:
+        raise TypeError("Can't convert {!r} to a color component".format(v))
+
+
+def as_hex(x):
+    """ Convert any vague color description to a hex color """
+    try:
+        return operator.index(x)
+    except TypeError:
+        return rgb2hex(x)
+
+
+class Color(IntEnum):
+    BLUE = 0x000000FF
+    RED = 0x00FF0000
+    GREEN = 0x0000FF00
+    YELLOW = 0x00FFFF00
+    MAGENTA = 0x00FF00FF
+    CYAN = 0x0000FFFF
+    BLACK = 0x00000000

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 import subprocess
-from distutils.command.install import install
+from setuptools.command.install import install
 from distutils.command.build import build
 from os import path
 import os

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     url='https://github.com/hugohadfield/pyganja',
-    license='',
+    license='MIT',
     author='Hugo Hadfield',
     author_email='hadfield.hugo@gmail.com',
     description='Python interface to ganja.js',


### PR DESCRIPTION
This means that the caller can now use any of the following in the `color` argument, all with the same meaning:

* `0x00FF0000`
* `(255, 0, 0)`
* `(0, 255, 0, 0)`
* `(1.0, 0.0, 0.0)`