### PR TITLE
Fix error that happened when not in Jupyter

### DIFF
--- a/pyganja/script_api.py
+++ b/pyganja/script_api.py
@@ -182,7 +182,7 @@ def render_browser_script(script_json, sig=None, grid=True, scale=1.0, gl=True, 
     if filename is None:
         hash_object = hashlib.md5(html_code.encode())
         filename = hash_object.hexdigest() + '.html'
-    with open(filename,'w') as fo:
+    with open(filename, 'w', encoding='utf8') as fo:
         print(html_code,file=fo)
     webbrowser.open(filename)
 


### PR DESCRIPTION
```

  Message='charmap' codec can't encode characters in position 73335-73353: character maps to <undefined>
  Source=C:\Users\jakka\Documents\Visual Studio 2019\Projects\Eric-Wieser-Lecture\Eric-Wieser-Lecture\Eric_Wieser_Lecture.py
  StackTrace:
  File "C:\Users\jakka\Documents\Visual Studio 2019\Projects\Eric-Wieser-Lecture\Eric-Wieser-Lecture\Eric_Wieser_Lecture.py", line 18, in <module>
    draw([S])
```